### PR TITLE
Added main.yaml to deploy full cft stack, docker, compose, bamboo

### DIFF
--- a/infra-ansible/main.yaml
+++ b/infra-ansible/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy Cloudformation Stack
-
+  hosts: localhost
   tasks:
 
   - name: Deploy Stack
@@ -14,30 +14,88 @@
   - name: Get summary information about a stack
     amazon.aws.cloudformation_info:
       stack_name: "TheDarkEdgeLordsofCode"
+      region: us-east-1
     register: stackOutput
+
+  # - name: print
+  #   debug:
+  #     msg: "{{ stackOutput['cloudformation']['TheDarkEdgeLordsofCode']['stack_outputs']['InfraPublicDNS'] }}"
 
   - name: Assign new Infra Inventory
     add_host:
-      name: "{{ stackOutput['cloudformation']['TheDarkEdgeLordsofCode']['stack_description']['outputs']['InfraPublicDNS'] }}"
+      name: "{{ stackOutput['cloudformation']['TheDarkEdgeLordsofCode']['stack_outputs']['InfraPublicDNS'] }}"
       groups:
       - cfm
       - infra
   - name: Assign new Staging Inventory
     add_host:
-      name: "{{ stackOutput['cloudformation']['TheDarkEdgeLordsofCode']['stack_description']['outputs']['StagingPublicDNS'] }}"
+      name: "{{ stackOutput['cloudformation']['TheDarkEdgeLordsofCode']['stack_outputs']['StagingPublicDNS'] }}"
       groups: cfm
   - name: Assign new Prod Inventory
     add_host:
-      name: "{{ stackOutput['cloudformation']['TheDarkEdgeLordsofCode']['stack_description']['outputs']['ProdPublicDNS'] }}"
+      name: "{{ stackOutput['cloudformation']['TheDarkEdgeLordsofCode']['stack_outputs']['ProdPublicDNS'] }}"
       groups: cfm
 
 - name: Deploy Docker & Docker Compose
   hosts: cfm
 
   tasks:
+  - name: Add Apt Repo
+    ansible.builtin.apt_repository:
+      repo: deb http://archive.ubuntu.com/ubuntu bionic universe
+      state: present
+      filename: docker-compose
+
+  - name: Apt Update
+    ansible.builtin.apt:
+      update_cache: yes
+
+  - name: Install Docker-Compose
+    ansible.builtin.apt:
+      name: docker-compose
+      state: present
+
+  - name: Install Python
+    ansible.builtin.apt:
+      name: python
+      state: present
+
+  - name: install Python pip3
+    ansible.builtin.apt:
+      name: python3-pip
+
+  - name: Install Docker
+    ansible.builtin.pip:
+      name: docker
+      executable: pip3
+
+  - name: Start Docker
+    service:
+      name: docker
+      state: started
 
 - name: Deploy Bamboo
   hosts: infra
 
   tasks:
+  - name: Create Volume
+    community.docker.docker_volume:
+      name: bambooVolume
+      state: present
+
+  - name:
+    community.docker.docker_container:
+      name: bamboo
+      image: jrrickerson/capstone-bamboo
+      state: started
+      detach: true
+      groups: docker
+      restart_policy: always
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - bambooVolume:/var/atlassian/application-data/bamboo
+      ports:
+        - "54663:54663"
+        - "8085:8085"
+
 


### PR DESCRIPTION
Should be run by using `ansible-playbook --private-key /path/to/AWS.pem main.yaml`

No host file needed